### PR TITLE
Improve UI text visibility

### DIFF
--- a/src/components/BillManager.jsx
+++ b/src/components/BillManager.jsx
@@ -249,7 +249,7 @@ const BillManager = ({ bills, onAddBill, onUpdateBill, onDeleteBill }) => {
             setEditingBill(null);
             resetForm();
           }}
-          className="bg-gradient-to-r from-purple-500 to-purple-600 text-white px-6 py-3 rounded-xl hover:from-purple-600 hover:to-purple-700 transition-all duration-200 flex items-center shadow-lg hover:shadow-xl transform hover:scale-105 border border-purple-400/30 w-full md:w-auto"
+          className="bg-gradient-to-r from-purple-500 to-purple-600 text-white font-semibold px-4 py-2 rounded-lg hover:from-purple-600 hover:to-purple-700 transition-all duration-200 flex items-center shadow-lg hover:shadow-xl transform hover:scale-105 border border-purple-400/30 w-auto"
         >
           <Plus className="h-4 w-4 mr-2" />
           Add Bill
@@ -542,7 +542,7 @@ const BillManager = ({ bills, onAddBill, onUpdateBill, onDeleteBill }) => {
                 </button>
                 <button
                   type="submit"
-                  className="flex-1 bg-gradient-to-r from-purple-500 to-purple-600 text-white py-3 rounded-xl hover:from-purple-600 hover:to-purple-700 transition-all duration-200 flex items-center justify-center shadow-lg hover:shadow-xl transform hover:scale-105 border border-purple-400/30 font-medium w-full sm:w-auto"
+                  className="flex-1 bg-gradient-to-r from-purple-500 to-purple-600 text-white font-semibold px-4 py-2 rounded-lg hover:from-purple-600 hover:to-purple-700 transition-all duration-200 flex items-center justify-center shadow-lg hover:shadow-xl transform hover:scale-105 border border-purple-400/30 w-auto"
                 >
                   <Save className="h-4 w-4 mr-2" />
                   {editingBill ? "Update Bill" : "Add Bill"}

--- a/src/components/ChartsAndAnalytics.jsx
+++ b/src/components/ChartsAndAnalytics.jsx
@@ -378,7 +378,7 @@ const ChartsAnalytics = ({
             </div>
             Analytics & Reports
           </h2>
-          <p className="text-gray-600 mt-1">
+          <p className="text-gray-800 mt-1">
             Financial insights and spending patterns
           </p>
         </div>

--- a/src/components/SavingsGoals.jsx
+++ b/src/components/SavingsGoals.jsx
@@ -277,7 +277,7 @@ const SavingsGoals = ({
             <Target className="h-5 w-5 mr-2 text-purple-600" />
             Savings Goals ({savingsGoals.length})
           </h2>
-          <p className="text-sm text-gray-600 mt-1">
+          <p className="text-sm text-gray-800 mt-1">
             ${totalSaved.toFixed(2)} of ${totalTargets.toFixed(2)} saved (
             {overallProgress.toFixed(1)}%)
           </p>

--- a/src/components/TransactionLedger.jsx
+++ b/src/components/TransactionLedger.jsx
@@ -386,7 +386,7 @@ const TransactionLedger = ({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+      <div className="flex flex-wrap md:flex-nowrap justify-between items-start md:items-center gap-4">
         <div>
           <h2 className="text-2xl font-bold flex items-center text-gray-900">
             <div className="relative mr-4">
@@ -402,17 +402,17 @@ const TransactionLedger = ({
           </p>
         </div>
         
-        <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex flex-row gap-3">
           <button
             onClick={() => setShowImportModal(true)}
-            className="bg-gradient-to-r from-cyan-500 to-cyan-600 text-white px-6 py-3 rounded-xl hover:from-cyan-600 hover:to-cyan-700 transition-all duration-200 flex items-center shadow-lg hover:shadow-xl transform hover:scale-105 border border-cyan-400/30 w-full sm:w-auto"
+            className="bg-gradient-to-r from-cyan-500 to-cyan-600 text-white font-semibold px-4 py-2 rounded-lg hover:from-cyan-600 hover:to-cyan-700 transition-all duration-200 flex items-center shadow-lg hover:shadow-xl transform hover:scale-105 border border-cyan-400/30 w-auto"
           >
             <Upload className="h-4 w-4 mr-2" />
             Import File
           </button>
           <button
             onClick={() => setShowAddModal(true)}
-            className="bg-gradient-to-r from-emerald-500 to-emerald-600 text-white px-6 py-3 rounded-xl hover:from-emerald-600 hover:to-emerald-700 transition-all duration-200 flex items-center shadow-lg hover:shadow-xl transform hover:scale-105 border border-emerald-400/30 w-full sm:w-auto"
+            className="bg-gradient-to-r from-emerald-500 to-emerald-600 text-white font-semibold px-4 py-2 rounded-lg hover:from-emerald-600 hover:to-emerald-700 transition-all duration-200 flex items-center shadow-lg hover:shadow-xl transform hover:scale-105 border border-emerald-400/30 w-auto"
           >
             <Plus className="h-4 w-4 mr-2" />
             Add Transaction


### PR DESCRIPTION
## Summary
- tweak `Add Bill` buttons for better contrast and smaller width
- keep buttons in the transaction ledger on one line and brighten their styling
- darken the subtitle in Analytics & Reports
- darken the subtitle in Savings Goals

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68803a9bc8fc832cb25fa1f9d1c630be