### PR TITLE
Fix import to load data immediately

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -143,7 +143,7 @@ const Layout = () => {
     }
   };
 
-  const importData = async (event, setDebugInfo) => {
+const importData = async (event, setDebugInfo) => {
     const file = event.target.files[0];
     if (!file) return;
 
@@ -385,6 +385,8 @@ const Layout = () => {
       alert(
         `Successfully imported data!\n\nEnvelopes: ${dataToLoad.envelopes.length}\nBills: ${dataToLoad.bills.length}\nTransactions: ${dataToLoad.allTransactions.length}\n\nData saved to localStorage. If it doesn't appear, try the Force Load Data button.`
       );
+
+      return dataToLoad;
     } catch (error) {
       console.error("❌ Import failed:", error);
       console.error("❌ Import error details:", {
@@ -518,6 +520,14 @@ const MainContent = ({
   const [activeView, setActiveView] = useState("dashboard");
   const [debugInfo, setDebugInfo] = useState(null);
   const [forceLoadDebug, setForceLoadDebug] = useState(null);
+
+  // Handle import by saving data then loading into context
+  const handleImport = async (event) => {
+    const data = await onImport(event, setDebugInfo);
+    if (data) {
+      budget.loadData(data);
+    }
+  };
 
   // Debug panel for live site
   const forceLoadData = async () => {
@@ -1005,7 +1015,7 @@ const MainContent = ({
           currentUser={currentUser}
           onUserChange={onUserChange}
           onExport={onExport}
-          onImport={(event) => onImport(event, setDebugInfo)}
+          onImport={handleImport}
           onLogout={onLogout}
           onResetEncryption={onResetEncryption}
         />


### PR DESCRIPTION
## Summary
- when importing data, return the processed dataset
- load imported dataset into BudgetContext state
- update `Header` to use new handler

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68825efdfd8c832c97093a85e50bbc01