### PR TITLE
Fix EnvelopeGrid crash on imported data

### DIFF
--- a/src/components/budgeting/EnvelopeGrid.jsx
+++ b/src/components/budgeting/EnvelopeGrid.jsx
@@ -89,8 +89,17 @@ const EnvelopeGrid = ({
 
         {/* Bill Envelopes */}
         {envelopes.map((envelope) => {
+          // Some imported data may not contain a monthlyAmount field. Fallback
+          // to a value derived from the biweekly allocation (approximate
+          // monthly amount) or 0 to avoid runtime errors when calling toFixed.
+          const monthlyAmount =
+            envelope.monthlyAmount ??
+            (envelope.biweeklyAllocation
+              ? (envelope.biweeklyAllocation * 26) / 12
+              : 0);
+
           const isLow = envelope.currentBalance < envelope.biweeklyAllocation;
-          const isOverfunded = envelope.currentBalance > envelope.monthlyAmount;
+          const isOverfunded = envelope.currentBalance > monthlyAmount;
 
           return (
             <div
@@ -128,7 +137,7 @@ const EnvelopeGrid = ({
                 ${envelope.currentBalance.toFixed(2)}
               </p>
               <div className="text-sm opacity-90">
-                <p>Monthly: ${envelope.monthlyAmount.toFixed(2)}</p>
+                <p>Monthly: ${monthlyAmount.toFixed(2)}</p>
                 <p>Biweekly: ${envelope.biweeklyAllocation.toFixed(2)}</p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- prevent crash when monthlyAmount missing from imported envelope

## Testing
- `npm run format:check`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6882628f5b94832c918e9dcdda741837