### PR TITLE
Fix reset z-index and envelope creation

### DIFF
--- a/src/components/bills/BillManager.jsx
+++ b/src/components/bills/BillManager.jsx
@@ -153,16 +153,19 @@ const BillManager = ({ bills, onAddBill, onUpdateBill, onDeleteBill, onAddEnvelo
       // Create envelope if requested
       if (formData.createEnvelope && onAddEnvelope) {
         const envelopeData = {
-          id: `envelope_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+          id: `bill_${billData.id}`,
           name: formData.name,
-          targetAmount: billData.biweeklyAmount,
+          biweeklyAllocation: billData.biweeklyAmount,
           currentBalance: 0,
           category: formData.category,
           color: formData.color,
           priority: "medium",
           dueDate: formData.dueDate,
-          billId: billData.id,
+          linkedBillId: billData.id,
           notes: `Auto-created for ${formData.name} bill`,
+          targetAmount: billData.biweeklyAmount * 2,
+          spendingHistory: [],
+          isFromBill: true,
         };
         onAddEnvelope(envelopeData);
       }

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -453,7 +453,7 @@ const MainContent = ({
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-400 via-purple-500 to-indigo-600 p-4 sm:px-6 md:px-8 overflow-x-hidden">
-      <div className="max-w-7xl mx-auto relative z-10">
+      <div className="max-w-7xl mx-auto relative z-50">
         <Header
           currentUser={currentUser}
           onUserChange={onUserChange}


### PR DESCRIPTION
## Summary
- keep the header above the page content so the Reset dropdown is clickable
- properly link envelopes created from the Add Bill form

## Testing
- `npm run format:check`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6886a03158e8832c8d36f1eec8e2adfb