### PR TITLE
Fix infinite render loop from activity update

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,5 +1,5 @@
 // src/components/layout/Layout.jsx
-import React, { useState, useEffect, Suspense, lazy } from "react";
+import React, { useState, useEffect, useCallback, Suspense, lazy } from "react";
 import { useAuth } from "../../contexts/AuthContext";
 import { BudgetProvider, useBudget } from "../../contexts/BudgetContext";
 import UserSetup from "../auth/UserSetup";
@@ -47,10 +47,10 @@ const Layout = () => {
   const [syncConflicts, setSyncConflicts] = useState(null);
 
   // Handle activity updates from MainContent
-  const handleActivityUpdate = ({ users, activity }) => {
+  const handleActivityUpdate = useCallback(({ users, activity }) => {
     setActiveUsers(users);
     setRecentActivity(activity);
-  };
+  }, []);
   const handleSetup = async (userData) => {
     logger.auth("Layout handleSetup called", { hasUserData: !!userData });
     try {


### PR DESCRIPTION
## Summary
- prevent activity sync handler from recreating each render

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run format:check` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688782cd6674832c8d69126c3cde9f7f