### PR TITLE
Add profile customization modal

### DIFF
--- a/src/components/auth/ProfileModal.jsx
+++ b/src/components/auth/ProfileModal.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { X } from "lucide-react";
+import { useAuth } from "../../contexts/AuthContext";
+
+const ProfileModal = ({ onClose }) => {
+  const { currentUser, updateUser } = useAuth();
+  const [name, setName] = useState(currentUser?.userName || "");
+  const [color, setColor] = useState(currentUser?.userColor || "#a855f7");
+  const [avatar, setAvatar] = useState(currentUser?.avatar || "");
+
+  const colors = [
+    { name: "Purple", value: "#a855f7" },
+    { name: "Emerald", value: "#10b981" },
+    { name: "Cyan", value: "#06b6d4" },
+    { name: "Rose", value: "#f43f5e" },
+    { name: "Amber", value: "#f59e0b" },
+    { name: "Indigo", value: "#6366f1" },
+    { name: "Pink", value: "#ec4899" },
+    { name: "Teal", value: "#14b8a6" },
+  ];
+
+  const handleAvatarChange = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (ev) => setAvatar(ev.target.result);
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleSave = () => {
+    const updatedUser = {
+      ...currentUser,
+      userName: name.trim() || currentUser.userName,
+      userColor: color,
+      avatar,
+    };
+    updateUser(updatedUser);
+    localStorage.setItem(
+      "userProfile",
+      JSON.stringify({ userName: updatedUser.userName, userColor: updatedUser.userColor, avatar })
+    );
+    if (onClose) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+    >
+      <div
+        className="glassmorphism rounded-2xl p-6 w-full max-w-sm border border-white/30 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold">Edit Profile</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="space-y-4">
+          <div className="flex flex-col items-center space-y-3">
+            {avatar ? (
+              <img src={avatar} alt="Avatar" className="w-20 h-20 rounded-full object-cover" />
+            ) : (
+              <div className="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-gray-500">
+                No Avatar
+              </div>
+            )}
+            <input type="file" accept="image/*" onChange={handleAvatarChange} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Color</label>
+            <div className="grid grid-cols-4 gap-2">
+              {colors.map((c) => (
+                <button
+                  key={c.value}
+                  type="button"
+                  onClick={() => setColor(c.value)}
+                  className={`w-8 h-8 rounded-full border-2 ${
+                    color === c.value ? "border-gray-900 scale-110 shadow-lg" : "border-gray-200 hover:border-gray-400"
+                  }`}
+                  style={{ backgroundColor: c.value }}
+                  title={c.name}
+                />
+              ))}
+            </div>
+          </div>
+          <button onClick={handleSave} className="btn btn-primary w-full mt-2">
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileModal;

--- a/src/components/auth/UserIndicator.jsx
+++ b/src/components/auth/UserIndicator.jsx
@@ -1,19 +1,33 @@
-import React, { memo } from "react";
+import React, { memo, useState } from "react";
 import { User, ChevronDown } from "lucide-react";
+import ProfileModal from "./ProfileModal";
 
 const UserIndicator = memo(({ currentUser, onUserChange }) => {
+  const [showProfile, setShowProfile] = useState(false);
+
   if (!currentUser) {
     return null;
   }
 
   return (
     <div className="flex items-center gap-3">
-      <div className="flex items-center glassmorphism rounded-2xl px-5 py-3 shadow-xl border border-white/30 backdrop-blur-sm">
+      <div
+        className="flex items-center glassmorphism rounded-2xl px-5 py-3 shadow-xl border border-white/30 backdrop-blur-sm cursor-pointer"
+        onClick={() => setShowProfile(true)}
+      >
         <div
           className="w-3 h-3 rounded-full mr-3 shadow-sm ring-2 ring-white/50"
           style={{ backgroundColor: currentUser?.userColor || "#a855f7" }}
         />
-        <User className="h-4 w-4 text-gray-700 mr-2" />
+        {currentUser.avatar ? (
+          <img
+            src={currentUser.avatar}
+            alt="avatar"
+            className="h-5 w-5 rounded-full mr-2 object-cover"
+          />
+        ) : (
+          <User className="h-4 w-4 text-gray-700 mr-2" />
+        )}
         <span className="font-semibold text-gray-900 text-sm">
           {currentUser?.userName || "Anonymous"}
         </span>
@@ -23,6 +37,7 @@ const UserIndicator = memo(({ currentUser, onUserChange }) => {
       <button onClick={onUserChange} className="btn btn-secondary">
         Switch User
       </button>
+      {showProfile && <ProfileModal onClose={() => setShowProfile(false)} />}
     </div>
   );
 });

--- a/src/components/auth/UserSetup.jsx
+++ b/src/components/auth/UserSetup.jsx
@@ -11,6 +11,7 @@ const UserSetup = ({ onSetupComplete }) => {
   const [masterPassword, setMasterPassword] = useState("");
   const [userName, setUserName] = useState("");
   const [userColor, setUserColor] = useState("#a855f7");
+  const [avatar, setAvatar] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -22,6 +23,15 @@ const UserSetup = ({ onSetupComplete }) => {
         setTimeout(() => reject(new Error(`Operation timed out after ${timeoutMs}ms`)), timeoutMs)
       ),
     ]);
+  };
+
+  const handleAvatarChange = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (ev) => setAvatar(ev.target.result);
+      reader.readAsDataURL(file);
+    }
   };
 
   const [isReturningUser, setIsReturningUser] = useState(false);
@@ -38,6 +48,7 @@ const UserSetup = ({ onSetupComplete }) => {
         console.log("📋 Found saved profile:", profile);
         setUserName(profile.userName || "");
         setUserColor(profile.userColor || "#a855f7");
+        setAvatar(profile.avatar || "");
         setIsReturningUser(true);
         console.log("👋 Returning user detected");
       } catch (error) {
@@ -84,6 +95,7 @@ const UserSetup = ({ onSetupComplete }) => {
         password: masterPassword,
         userName: userName.trim(),
         userColor,
+        avatar,
       });
       console.log("✅ onSetupComplete succeeded");
     } catch (error) {
@@ -115,6 +127,7 @@ const UserSetup = ({ onSetupComplete }) => {
           password: masterPassword,
           userName,
           userColor,
+          avatar,
         });
         console.log("✅ Returning user login succeeded");
       } catch (error) {
@@ -157,6 +170,7 @@ const UserSetup = ({ onSetupComplete }) => {
           password: masterPassword,
           userName: userName.trim(),
           userColor,
+          avatar,
         });
       }, 10000);
 
@@ -174,6 +188,7 @@ const UserSetup = ({ onSetupComplete }) => {
     localStorage.removeItem("userProfile");
     setUserName("");
     setUserColor("#a855f7");
+    setAvatar("");
     setStep(1);
   };
 
@@ -320,6 +335,23 @@ const UserSetup = ({ onSetupComplete }) => {
                     />
                   ))}
                 </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-3">Avatar (optional)</label>
+                {avatar && (
+                  <img
+                    src={avatar}
+                    alt="avatar preview"
+                    className="w-20 h-20 rounded-full object-cover mb-2"
+                  />
+                )}
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={handleAvatarChange}
+                  disabled={isLoading}
+                />
               </div>
 
               <div className="flex gap-3">

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -85,6 +85,7 @@ export const AuthProvider = ({ children }) => {
           const profileData = {
             userName: finalUserData.userName,
             userColor: finalUserData.userColor,
+            avatar: finalUserData.avatar || "",
           };
           localStorage.setItem("userProfile", JSON.stringify(profileData));
           logger.auth("Saved user profile to localStorage.");
@@ -159,6 +160,13 @@ export const AuthProvider = ({ children }) => {
           setBudgetId(currentUserData.budgetId);
           setIsUnlocked(true);
           setLastActivity(Date.now());
+
+          const existingProfile = {
+            userName: currentUserData.userName,
+            userColor: currentUserData.userColor,
+            avatar: currentUserData.avatar || "",
+          };
+          localStorage.setItem("userProfile", JSON.stringify(existingProfile));
 
           return { success: true, data: migratedData };
         }


### PR DESCRIPTION
## Summary
- let users edit their profile information
- support avatar upload, color and name updates during setup
- persist profile updates in AuthContext and localStorage
- show avatar and open profile modal from user indicator

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install @eslint/js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6888f342a798832ca15c24f394d78226