### PR TITLE
Fix zustand store persistence

### DIFF
--- a/src/stores/budgetStore.js
+++ b/src/stores/budgetStore.js
@@ -1,9 +1,12 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import { actionTypes, budgetReducer, initialState } from "../contexts/budgetState";
 
-const useBudgetStore = create((set, get) => ({
-  ...initialState,
-  dispatch: (action) => set((state) => budgetReducer(state, action)),
+const useBudgetStore = create(
+  persist(
+    (set, get) => ({
+      ...initialState,
+      dispatch: (action) => set((state) => budgetReducer(state, action)),
 
   setEnvelopes: (envelopes) =>
     get().dispatch({ type: actionTypes.SET_ENVELOPES, payload: envelopes }),
@@ -38,7 +41,12 @@ const useBudgetStore = create((set, get) => ({
   reconcileTransaction: (data) =>
     get().dispatch({ type: actionTypes.RECONCILE_TRANSACTION, payload: data }),
   loadData: (data) => get().dispatch({ type: actionTypes.LOAD_DATA, payload: data }),
-  resetAllData: () => get().dispatch({ type: actionTypes.RESET_ALL_DATA }),
-}));
+      resetAllData: () => get().dispatch({ type: actionTypes.RESET_ALL_DATA }),
+    }),
+    {
+      name: "budget-store",
+    }
+  )
+);
 
 export default useBudgetStore;


### PR DESCRIPTION
## Summary
- use Zustand's `persist` middleware to keep budget data in `localStorage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68894b13f3ec832c95a60de53e079a73