### PR TITLE
Improve mobile layout

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -526,7 +526,7 @@ const MainContent = ({
   const totalCash = totalEnvelopeBalance + totalSavingsBalance + unassignedCash;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-400 via-purple-500 to-indigo-600 p-4 sm:px-6 md:px-8 overflow-x-hidden">
+    <div className="min-h-screen bg-gradient-to-br from-purple-400 via-purple-500 to-indigo-600 p-4 sm:px-6 md:px-8 overflow-x-hidden pb-24 sm:pb-0">
       <div className="max-w-7xl mx-auto relative">
         <div className="relative z-50">
           <Header
@@ -557,8 +557,8 @@ const MainContent = ({
         */}
 
         {/* Navigation Tabs */}
-        <div className="glassmorphism rounded-3xl mb-6 shadow-xl border border-white/20">
-          <nav className="flex justify-center overflow-x-auto flex-wrap">
+        <div className="glassmorphism rounded-t-3xl sm:rounded-3xl mb-6 sm:shadow-xl border border-white/20 fixed bottom-0 left-0 right-0 sm:static z-40">
+          <nav className="flex justify-around overflow-x-auto">
             <NavButton
               key="dashboard"
               active={activeView === "dashboard"}
@@ -730,14 +730,14 @@ const NavButton = (
 ) => (
   <button
     onClick={onClick}
-    className={`px-8 py-5 text-sm font-semibold border-b-2 transition-all ${
+    className={`flex-1 flex flex-col items-center sm:flex-row sm:px-6 px-2 py-3 text-xs sm:text-sm font-semibold border-t-2 sm:border-b-2 transition-all ${
       active
         ? "border-purple-500 text-purple-600 bg-purple-50/50"
         : "border-transparent text-gray-600 hover:text-purple-600 hover:bg-purple-50/30"
     }`}
   >
-    <Icon className="h-5 w-5 inline mr-3" />
-    {label}
+    <Icon className="h-5 w-5 mb-1 sm:mb-0 sm:mr-3" />
+    <span>{label}</span>
   </button>
 );
 


### PR DESCRIPTION
## Summary
- fix layout padding for bottom nav on small screens
- move nav bar to the bottom on mobile
- make nav buttons responsive

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_688a28f0c2f0832c95fab8bbc75d3857