### PR TITLE
Add payday predictions and toast alerts

### DIFF
--- a/src/components/layout/Dashboard.jsx
+++ b/src/components/layout/Dashboard.jsx
@@ -1,5 +1,5 @@
 // components/Dashboard.jsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   CreditCard,
   CheckCircle,
@@ -14,6 +14,8 @@ import {
   Minus,
   RefreshCw,
 } from "lucide-react";
+import Toast from "../ui/Toast";
+import { isTodayPredictedPayday } from "../../utils/paydayPredictor";
 
 const Dashboard = ({
   envelopes,
@@ -23,8 +25,10 @@ const Dashboard = ({
   onUpdateActualBalance,
   onReconcileTransaction,
   transactions,
+  paycheckHistory,
 }) => {
   const [showReconcileModal, setShowReconcileModal] = useState(false);
+  const [showPaydayToast, setShowPaydayToast] = useState(false);
   const [newTransaction, setNewTransaction] = useState({
     amount: "",
     description: "",
@@ -32,6 +36,12 @@ const Dashboard = ({
     envelopeId: "",
     date: new Date().toISOString().split("T")[0],
   });
+
+  useEffect(() => {
+    if (isTodayPredictedPayday(paycheckHistory)) {
+      setShowPaydayToast(true);
+    }
+  }, [paycheckHistory]);
 
   // Calculate totals
   const totalEnvelopeBalance = envelopes.reduce((sum, env) => sum + env.currentBalance, 0);
@@ -88,6 +98,18 @@ const Dashboard = ({
 
   return (
     <div className="space-y-6">
+      {isTodayPredictedPayday(paycheckHistory) && (
+        <div className="bg-purple-50 border border-purple-200 p-4 rounded-lg flex items-center space-x-3">
+          <Calendar className="h-5 w-5 text-purple-600" />
+          <span className="font-medium text-purple-800">Payday? Time to apply it to your budget!</span>
+        </div>
+      )}
+      {showPaydayToast && (
+        <Toast
+          message="Looks like today might be payday!"
+          onClose={() => setShowPaydayToast(false)}
+        />
+      )}
       {/* Account Balance Overview */}
       <div className="glassmorphism rounded-2xl p-6 border border-white/20">
         <h2 className="text-xl font-semibold mb-6 flex items-center">

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -817,6 +817,7 @@ const ViewRenderer = ({ activeView, budget, currentUser }) => {
         onUpdateActualBalance={setActualBalance}
         onReconcileTransaction={reconcileTransaction}
         transactions={safeTransactions}
+        paycheckHistory={paycheckHistory}
       />
     ),
     envelopes: (

--- a/src/components/ui/Toast.jsx
+++ b/src/components/ui/Toast.jsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from "react";
+
+const Toast = ({ message, duration = 5000, onClose }) => {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onClose && onClose();
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  return (
+    <div className="fixed bottom-6 right-6 bg-purple-600 text-white px-4 py-2 rounded-lg shadow-lg z-50">
+      {message}
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/utils/paydayPredictor.js
+++ b/src/utils/paydayPredictor.js
@@ -1,0 +1,24 @@
+export const predictNextPayday = (history) => {
+  if (!Array.isArray(history) || history.length < 2) return null;
+  const dates = history
+    .map((p) => new Date(p.date))
+    .filter((d) => !isNaN(d));
+  if (dates.length < 2) return null;
+  dates.sort((a, b) => a - b);
+  const intervals = [];
+  for (let i = 1; i < dates.length; i++) {
+    intervals.push(dates[i] - dates[i - 1]);
+  }
+  if (intervals.length === 0) return null;
+  const avgInterval =
+    intervals.reduce((sum, val) => sum + val, 0) / intervals.length;
+  const nextDate = new Date(dates[dates.length - 1].getTime() + avgInterval);
+  return nextDate;
+};
+
+export const isTodayPredictedPayday = (history) => {
+  const next = predictNextPayday(history);
+  if (!next) return false;
+  const today = new Date();
+  return next.toDateString() === today.toDateString();
+};


### PR DESCRIPTION
## Summary
- detect payday based on paycheck history
- show toast and dashboard message when predicted payday occurs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688a27ed154c832c9c9862f51ba393c4