### PR TITLE
Add basic profile chat window

### DIFF
--- a/src/components/chat/ChatWindow.jsx
+++ b/src/components/chat/ChatWindow.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect, useRef } from "react";
+import useAuthStore from "../../stores/authStore";
+import { chatService } from "../../utils/chatService";
+
+const ChatWindow = ({ budgetId }) => {
+  const { currentUser } = useAuthStore();
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState("");
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    if (!budgetId) return undefined;
+    const unsub = chatService.subscribe(budgetId, setMessages);
+    return () => unsub();
+  }, [budgetId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const sendMessage = async (e) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    await chatService.sendMessage(budgetId, {
+      userId: currentUser?.userId,
+      userName: currentUser?.userName,
+      text: text.trim(),
+    });
+    setText("");
+  };
+
+  return (
+    <div className="chat-window">
+      <div className="messages">
+        {messages.map((msg) => (
+          <div key={msg.id} className="message">
+            <strong>{msg.userName || "Anon"}</strong>: {msg.text}
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+      <form onSubmit={sendMessage} className="input-area">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Type a message..."
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+};
+
+export default ChatWindow;

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -12,6 +12,7 @@ import { encryptionUtils } from "../../utils/encryption";
 import FirebaseSync from "../../utils/firebaseSync";
 import logger from "../../utils/logger";
 import { getVersionInfo } from "../../utils/version";
+import ChatWindow from "../chat/ChatWindow";
 import {
   DollarSign,
   Wallet,
@@ -672,6 +673,9 @@ const MainContent = ({
             </div>
           </div>
         )}
+
+        {/* Chat Window */}
+        {isUnlocked && budgetId && <ChatWindow budgetId={budgetId} />}
 
         {/* Conflict Resolution Modal */}
         {syncConflicts?.hasConflict && (

--- a/src/styles.css
+++ b/src/styles.css
@@ -255,3 +255,20 @@ tbody tr:hover {
   outline: 2px solid #a855f7;
   outline-offset: 2px;
 }
+
+/* Chat window styles */
+.chat-window {
+  @apply fixed bottom-4 right-4 bg-white border rounded shadow-md w-64 flex flex-col max-h-80 z-40;
+}
+.chat-window .messages {
+  @apply overflow-y-auto p-2 text-sm flex-1;
+}
+.chat-window .input-area {
+  @apply p-2 border-t flex;
+}
+.chat-window input {
+  @apply flex-1 border rounded px-2;
+}
+.chat-window button {
+  @apply ml-2 px-3 py-1 bg-purple-500 text-white rounded;
+}

--- a/src/utils/chatService.js
+++ b/src/utils/chatService.js
@@ -1,0 +1,46 @@
+import { initializeApp } from "firebase/app";
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  query,
+  orderBy,
+  onSnapshot,
+  serverTimestamp,
+} from "firebase/firestore";
+import { firebaseConfig } from "./firebaseConfig";
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+class ChatService {
+  constructor() {
+    this.listeners = new Set();
+  }
+
+  sendMessage(budgetId, { userId, userName, text }) {
+    const messagesRef = collection(db, "budgets", budgetId, "chat");
+    return addDoc(messagesRef, {
+      userId,
+      userName,
+      text,
+      createdAt: serverTimestamp(),
+    });
+  }
+
+  subscribe(budgetId, callback) {
+    const messagesRef = collection(db, "budgets", budgetId, "chat");
+    const q = query(messagesRef, orderBy("createdAt", "asc"));
+    const unsub = onSnapshot(q, (snapshot) => {
+      const messages = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      callback(messages);
+    });
+    this.listeners.add(unsub);
+    return () => {
+      unsub();
+      this.listeners.delete(unsub);
+    };
+  }
+}
+
+export const chatService = new ChatService();


### PR DESCRIPTION
## Summary
- add `ChatWindow` component for small profile chat
- implement `chatService` for Firebase interactions
- render `ChatWindow` in `Layout`
- style chat window

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688a251d241c832c949b2c4b830d0a96