### PR TITLE
Add profile customization

### DIFF
--- a/src/components/auth/ProfileSettings.jsx
+++ b/src/components/auth/ProfileSettings.jsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from "react";
+import { X, User as UserIcon } from "lucide-react";
+import useAuthStore from "../../stores/authStore";
+
+const colors = [
+  { name: "Purple", value: "#a855f7" },
+  { name: "Emerald", value: "#10b981" },
+  { name: "Cyan", value: "#06b6d4" },
+  { name: "Rose", value: "#f43f5e" },
+  { name: "Amber", value: "#f59e0b" },
+  { name: "Indigo", value: "#6366f1" },
+  { name: "Pink", value: "#ec4899" },
+  { name: "Teal", value: "#14b8a6" },
+];
+
+const ProfileSettings = ({ isOpen = false, onClose }) => {
+  const { currentUser, updateUser } = useAuthStore();
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(colors[0].value);
+  const [avatar, setAvatar] = useState(null);
+
+  useEffect(() => {
+    if (currentUser) {
+      setName(currentUser.userName || "");
+      setColor(currentUser.userColor || colors[0].value);
+      setAvatar(currentUser.userAvatar || null);
+    }
+  }, [currentUser]);
+
+  if (!isOpen) return null;
+
+  const handleAvatarChange = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setAvatar(reader.result);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleSave = async () => {
+    await updateUser({ ...currentUser, userName: name.trim(), userColor: color, userAvatar: avatar });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-2xl w-full max-w-sm p-6 shadow-2xl">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold">Edit Profile</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="space-y-4">
+          <div className="flex flex-col items-center">
+            <label htmlFor="avatar-input" className="cursor-pointer">
+              {avatar ? (
+                <img src={avatar} alt="Avatar" className="h-16 w-16 rounded-full object-cover" />
+              ) : (
+                <div className="h-16 w-16 rounded-full bg-gray-200 flex items-center justify-center">
+                  <UserIcon className="h-8 w-8 text-gray-500" />
+                </div>
+              )}
+            </label>
+            <input id="avatar-input" type="file" accept="image/*" className="hidden" onChange={handleAvatarChange} />
+            <p className="text-sm text-gray-500 mt-1">Click to change avatar</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg"
+              maxLength={40}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Color</label>
+            <div className="grid grid-cols-4 gap-3">
+              {colors.map((c) => (
+                <button
+                  key={c.value}
+                  type="button"
+                  onClick={() => setColor(c.value)}
+                  className={`w-8 h-8 rounded-full border-2 ${
+                    color === c.value ? "border-gray-900" : "border-gray-200"
+                  }`}
+                  style={{ backgroundColor: c.value }}
+                />
+              ))}
+            </div>
+          </div>
+
+          <button onClick={handleSave} className="btn btn-primary w-full mt-2">
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileSettings;

--- a/src/components/auth/UserIndicator.jsx
+++ b/src/components/auth/UserIndicator.jsx
@@ -1,7 +1,7 @@
 import React, { memo } from "react";
-import { User, ChevronDown } from "lucide-react";
+import { User, ChevronDown, Pencil } from "lucide-react";
 
-const UserIndicator = memo(({ currentUser, onUserChange }) => {
+const UserIndicator = memo(({ currentUser, onUserChange, onEditProfile }) => {
   if (!currentUser) {
     return null;
   }
@@ -13,13 +13,26 @@ const UserIndicator = memo(({ currentUser, onUserChange }) => {
           className="w-3 h-3 rounded-full mr-3 shadow-sm ring-2 ring-white/50"
           style={{ backgroundColor: currentUser?.userColor || "#a855f7" }}
         />
-        <User className="h-4 w-4 text-gray-700 mr-2" />
+        {currentUser?.userAvatar ? (
+          <img
+            src={currentUser.userAvatar}
+            alt="Avatar"
+            className="h-4 w-4 rounded-full mr-2 object-cover"
+          />
+        ) : (
+          <User className="h-4 w-4 text-gray-700 mr-2" />
+        )}
         <span className="font-semibold text-gray-900 text-sm">
           {currentUser?.userName || "Anonymous"}
         </span>
         <ChevronDown className="h-4 w-4 text-gray-500 ml-2" />
       </div>
 
+      {onEditProfile && (
+        <button onClick={onEditProfile} className="btn btn-secondary">
+          <Pencil className="h-4 w-4 mr-1" /> Edit
+        </button>
+      )}
       <button onClick={onUserChange} className="btn btn-secondary">
         Switch User
       </button>

--- a/src/components/auth/UserSetup.jsx
+++ b/src/components/auth/UserSetup.jsx
@@ -11,6 +11,7 @@ const UserSetup = ({ onSetupComplete }) => {
   const [masterPassword, setMasterPassword] = useState("");
   const [userName, setUserName] = useState("");
   const [userColor, setUserColor] = useState("#a855f7");
+  const [userAvatar, setUserAvatar] = useState(null);
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -38,6 +39,7 @@ const UserSetup = ({ onSetupComplete }) => {
         console.log("📋 Found saved profile:", profile);
         setUserName(profile.userName || "");
         setUserColor(profile.userColor || "#a855f7");
+        setUserAvatar(profile.userAvatar || null);
         setIsReturningUser(true);
         console.log("👋 Returning user detected");
       } catch (error) {
@@ -84,6 +86,7 @@ const UserSetup = ({ onSetupComplete }) => {
         password: masterPassword,
         userName: userName.trim(),
         userColor,
+        userAvatar,
       });
       console.log("✅ onSetupComplete succeeded");
     } catch (error) {
@@ -115,6 +118,7 @@ const UserSetup = ({ onSetupComplete }) => {
           password: masterPassword,
           userName,
           userColor,
+          userAvatar,
         });
         console.log("✅ Returning user login succeeded");
       } catch (error) {
@@ -126,6 +130,17 @@ const UserSetup = ({ onSetupComplete }) => {
     } else {
       // For new users, proceed to step 2
       setStep(2);
+    }
+  };
+
+  const handleAvatarInput = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setUserAvatar(reader.result);
+      };
+      reader.readAsDataURL(file);
     }
   };
 
@@ -157,6 +172,7 @@ const UserSetup = ({ onSetupComplete }) => {
           password: masterPassword,
           userName: userName.trim(),
           userColor,
+          userAvatar,
         });
       }, 10000);
 
@@ -174,6 +190,7 @@ const UserSetup = ({ onSetupComplete }) => {
     localStorage.removeItem("userProfile");
     setUserName("");
     setUserColor("#a855f7");
+    setUserAvatar(null);
     setStep(1);
   };
 
@@ -286,21 +303,35 @@ const UserSetup = ({ onSetupComplete }) => {
 
           {step === 2 && !isReturningUser && (
             <>
-              <div>
-                <label className="block text-sm font-semibold text-gray-700 mb-3">Your Name</label>
-                <input
-                  type="text"
-                  value={userName}
-                  onChange={(e) => {
-                    console.log("👤 Name input changed:", e.target.value);
-                    setUserName(e.target.value);
-                  }}
-                  placeholder="e.g., Sarah, John, etc."
-                  className="w-full px-4 py-3 border border-purple-200 rounded-2xl focus:ring-2 focus:ring-purple-500"
-                  disabled={isLoading}
-                  required
-                />
-              </div>
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-3">Your Name</label>
+            <input
+              type="text"
+              value={userName}
+              onChange={(e) => {
+                console.log("👤 Name input changed:", e.target.value);
+                setUserName(e.target.value);
+              }}
+              placeholder="e.g., Sarah, John, etc."
+              className="w-full px-4 py-3 border border-purple-200 rounded-2xl focus:ring-2 focus:ring-purple-500"
+              disabled={isLoading}
+              required
+            />
+          </div>
+
+          <div className="mt-4">
+            <label className="block text-sm font-semibold text-gray-700 mb-3">Avatar</label>
+            <div className="flex items-center gap-3">
+              {userAvatar ? (
+                <img src={userAvatar} alt="Avatar" className="h-12 w-12 rounded-full object-cover" />
+              ) : (
+                <div className="h-12 w-12 rounded-full bg-gray-200 flex items-center justify-center">
+                  <Users className="h-6 w-6 text-gray-500" />
+                </div>
+              )}
+              <input type="file" accept="image/*" onChange={handleAvatarInput} />
+            </div>
+          </div>
 
               <div>
                 <label className="block text-sm font-semibold text-gray-700 mb-3">Your Color</label>

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -8,6 +8,7 @@ import UserSetup from "../auth/UserSetup";
 import Header from "../ui/Header";
 import TeamActivitySync from "../sync/TeamActivitySync";
 import LoadingSpinner from "../ui/LoadingSpinner";
+import ProfileSettings from "../auth/ProfileSettings";
 import { encryptionUtils } from "../../utils/encryption";
 import FirebaseSync from "../../utils/firebaseSync";
 import logger from "../../utils/logger";
@@ -465,6 +466,7 @@ const MainContent = ({
 }) => {
   const budget = useBudget();
   const [activeView, setActiveView] = useState("dashboard");
+  const [showProfileSettings, setShowProfileSettings] = useState(false);
 
   // Handle import by saving data then loading into context
   const handleImport = async (event) => {
@@ -532,6 +534,7 @@ const MainContent = ({
           <Header
             currentUser={currentUser}
             onUserChange={onUserChange}
+            onEditProfile={() => setShowProfileSettings(true)}
             onExport={onExport}
             onImport={handleImport}
             onLogout={onLogout}
@@ -721,6 +724,12 @@ const MainContent = ({
           </div>
         </div>
       </div>
+      {showProfileSettings && (
+        <ProfileSettings
+          isOpen={showProfileSettings}
+          onClose={() => setShowProfileSettings(false)}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -4,7 +4,7 @@ import UserIndicator from "../auth/UserIndicator";
 import logoWithText from "../../assets/Logo with Text Final.png";
 
 const Header = memo(
-  ({ onExport, onImport, onLogout, onResetEncryption, currentUser, onUserChange }) => {
+  ({ onExport, onImport, onLogout, onResetEncryption, currentUser, onUserChange, onEditProfile }) => {
     const [showResetModal, setShowResetModal] = useState(false);
 
     const handleToggleResetModal = useCallback(() => {
@@ -32,7 +32,11 @@ const Header = memo(
 
           {/* Buttons row */}
           <div className="flex items-center justify-center flex-wrap gap-4">
-            <UserIndicator currentUser={currentUser} onUserChange={onUserChange} />
+            <UserIndicator
+              currentUser={currentUser}
+              onUserChange={onUserChange}
+              onEditProfile={onEditProfile}
+            />
 
             <div className="flex gap-3 items-center justify-center">
               <input


### PR DESCRIPTION
## Summary
- allow editing of name, color, and avatar after setup
- store profile changes in localStorage and encrypted budget
- show avatar indicator and edit button
- add ProfileSettings modal for editing

## Testing
- `npm install` *(fails: internet access blocked)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a1d3d1b00832c8acce1d0199fcac2