### PR TITLE
Fix invalid hook call by deduping React

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,11 @@ export default defineConfig({
       authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
   ],
+  // Avoid multiple copies of React which can cause
+  // "Invalid hook call" errors during development
+  resolve: {
+    dedupe: ["react", "react-dom"],
+  },
   define: {
     "process.env": {},
     global: {},


### PR DESCRIPTION
## Summary
- add `resolve.dedupe` in `vite.config.js` to ensure only one copy of React is used

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688a4d7a943c832c931a2851b18197a0