### PR TITLE
fix: populate ledger transactions

### DIFF
--- a/src/hooks/useFirebaseSync.js
+++ b/src/hooks/useFirebaseSync.js
@@ -30,9 +30,16 @@ const useFirebaseSync = (firebaseSync, encryptionKey, budgetId, currentUser) => 
           if (cloudData.data.envelopes) budget.setEnvelopes(cloudData.data.envelopes);
           if (cloudData.data.bills) budget.setBills(cloudData.data.bills);
           if (cloudData.data.savingsGoals) budget.setSavingsGoals(cloudData.data.savingsGoals);
-          if (cloudData.data.transactions) budget.setTransactions(cloudData.data.transactions);
-          if (cloudData.data.allTransactions)
+          if (cloudData.data.transactions) {
+            budget.setTransactions(cloudData.data.transactions);
+          }
+          if (cloudData.data.allTransactions) {
             budget.setAllTransactions(cloudData.data.allTransactions);
+          } else if (cloudData.data.transactions) {
+            // Fallback for older sync data that only has `transactions`
+            // Ensures the ledger isn't empty when allTransactions is missing
+            budget.setAllTransactions(cloudData.data.transactions);
+          }
           if (typeof cloudData.data.unassignedCash === "number")
             budget.setUnassignedCash(cloudData.data.unassignedCash);
           if (typeof cloudData.data.biweeklyAllocation === "number")

--- a/src/stores/budgetStore.js
+++ b/src/stores/budgetStore.js
@@ -56,6 +56,21 @@ const migrateOldData = () => {
         localStorage.removeItem("budget-store");
         console.log("🧹 Cleaned up old budget-store data");
       }
+    } else if (newData) {
+      // Ensure existing violet-vault-store data has allTransactions field
+      const parsedNewData = JSON.parse(newData);
+      if (
+        parsedNewData?.state &&
+        parsedNewData.state.transactions &&
+        (!parsedNewData.state.allTransactions ||
+          parsedNewData.state.allTransactions.length === 0)
+      ) {
+        parsedNewData.state.allTransactions = parsedNewData.state.transactions;
+        localStorage.setItem("violet-vault-store", JSON.stringify(parsedNewData));
+        console.log(
+          "✅ Added missing allTransactions to existing violet-vault-store data"
+        );
+      }
     }
   } catch (error) {
     console.warn("⚠️ Failed to migrate old data:", error);


### PR DESCRIPTION
## Summary
- ensure cloud sync populates `allTransactions` when the field is missing
- migrate existing local storage data to copy transactions into `allTransactions`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899dc008140832cad1de91460f62583