### PR TITLE
fix: restore envelope data in store

### DIFF
--- a/src/stores/budgetStore.js
+++ b/src/stores/budgetStore.js
@@ -89,9 +89,22 @@ const storeInitializer = (set, get) => ({
   dataLoaded: false,
   cloudSyncEnabled: true, // Toggle for Firestore cloud sync (default enabled)
 
+  // Data arrays used by queries and mutations
+  envelopes: [],
+  bills: [],
+  transactions: [],
+  allTransactions: [],
+  savingsGoals: [],
+  supplementalAccounts: [],
+  debts: [],
+
   // App state actions (data mutations now handled by TanStack Query hooks)
 
   // Optimized bulk operations
+  setEnvelopes: (envelopes) =>
+    set((state) => {
+      state.envelopes = envelopes;
+    }),
   bulkUpdateEnvelopes: (updates) =>
     set((state) => {
       updates.forEach((update) => {


### PR DESCRIPTION
## Summary
- reintroduce envelope-related arrays in budget store
- add setEnvelopes action so Firebase sync can populate envelopes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899dad4adbc832cb39131bbea59f614