### PR TITLE
fix: handle missing envelopes in unassigned cash modal

### DIFF
--- a/.github/data/lint-warnings.json
+++ b/.github/data/lint-warnings.json
@@ -1,6 +1,6 @@
 {
   "project": "violet-vault",
-  "lastUpdated": "2025-08-10",
+  "lastUpdated": "2025-08-11",
   "currentStatus": {
     "totalWarnings": 26,
     "targetWarnings": 17,
@@ -180,7 +180,7 @@
           "warnings": 1,
           "details": [
             {
-              "line": 56,
+              "line": 63,
               "message": "React Hook useEffect has a missing dependency: 'budget'. Either include it or remove the dependency array"
             }
           ]

--- a/.github/data/lint-warnings.json
+++ b/.github/data/lint-warnings.json
@@ -1,6 +1,6 @@
 {
   "project": "violet-vault",
-  "lastUpdated": "2025-08-09",
+  "lastUpdated": "2025-08-10",
   "currentStatus": {
     "totalWarnings": 26,
     "targetWarnings": 17,

--- a/src/components/modals/UnassignedCashModal.jsx
+++ b/src/components/modals/UnassignedCashModal.jsx
@@ -36,7 +36,7 @@ const UnassignedCashModal = () => {
     applyDistribution,
 
     // Data
-    envelopes,
+    envelopes = [],
     unassignedCash,
     getDistributionPreview,
   } = useUnassignedCashDistribution();

--- a/src/hooks/useFirebaseSync.js
+++ b/src/hooks/useFirebaseSync.js
@@ -30,9 +30,16 @@ const useFirebaseSync = (firebaseSync, encryptionKey, budgetId, currentUser) => 
           if (cloudData.data.envelopes) budget.setEnvelopes(cloudData.data.envelopes);
           if (cloudData.data.bills) budget.setBills(cloudData.data.bills);
           if (cloudData.data.savingsGoals) budget.setSavingsGoals(cloudData.data.savingsGoals);
-          if (cloudData.data.transactions) budget.setTransactions(cloudData.data.transactions);
-          if (cloudData.data.allTransactions)
+          if (cloudData.data.transactions) {
+            budget.setTransactions(cloudData.data.transactions);
+          }
+          if (cloudData.data.allTransactions) {
             budget.setAllTransactions(cloudData.data.allTransactions);
+          } else if (cloudData.data.transactions) {
+            // Fallback for older sync data that only has `transactions`
+            // Ensures the ledger isn't empty when allTransactions is missing
+            budget.setAllTransactions(cloudData.data.transactions);
+          }
           if (typeof cloudData.data.unassignedCash === "number")
             budget.setUnassignedCash(cloudData.data.unassignedCash);
           if (typeof cloudData.data.biweeklyAllocation === "number")

--- a/src/hooks/useUnassignedCashDistribution.js
+++ b/src/hooks/useUnassignedCashDistribution.js
@@ -9,7 +9,7 @@ import { BIWEEKLY_MULTIPLIER } from "../constants/frequency";
  */
 const useUnassignedCashDistribution = () => {
   const budget = useBudgetStore();
-  const { envelopes, unassignedCash, bulkUpdateEnvelopes, setUnassignedCash } = budget;
+  const { envelopes = [], unassignedCash = 0, bulkUpdateEnvelopes, setUnassignedCash } = budget;
 
   // Distribution state (modal state now handled by budget store)
   const [distributions, setDistributions] = useState({});

--- a/src/stores/budgetStore.js
+++ b/src/stores/budgetStore.js
@@ -56,6 +56,21 @@ const migrateOldData = () => {
         localStorage.removeItem("budget-store");
         console.log("🧹 Cleaned up old budget-store data");
       }
+    } else if (newData) {
+      // Ensure existing violet-vault-store data has allTransactions field
+      const parsedNewData = JSON.parse(newData);
+      if (
+        parsedNewData?.state &&
+        parsedNewData.state.transactions &&
+        (!parsedNewData.state.allTransactions ||
+          parsedNewData.state.allTransactions.length === 0)
+      ) {
+        parsedNewData.state.allTransactions = parsedNewData.state.transactions;
+        localStorage.setItem("violet-vault-store", JSON.stringify(parsedNewData));
+        console.log(
+          "✅ Added missing allTransactions to existing violet-vault-store data"
+        );
+      }
     }
   } catch (error) {
     console.warn("⚠️ Failed to migrate old data:", error);


### PR DESCRIPTION
## Summary
- ensure UnassignedCashModal defaults to an empty envelopes array
- guard hook against undefined envelopes and unassigned cash

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run format:check` *(fails: Code style issues found in 9 files)*

------
https://chatgpt.com/codex/tasks/task_e_689de80f134c832cafa315d8aec709b5