### PR TITLE
fix: handle missing envelopes in cash modal

### DIFF
--- a/src/components/modals/UnassignedCashModal.jsx
+++ b/src/components/modals/UnassignedCashModal.jsx
@@ -16,63 +16,54 @@ import useUnassignedCashDistribution from "../../hooks/useUnassignedCashDistribu
  * Modal for distributing unassigned cash to envelopes
  * Pure UI component - all logic handled by useUnassignedCashDistribution hook
  */
-const EnvelopeItem = memo(
-  ({ envelope, distributionAmount, updateDistribution, isProcessing }) => {
-    const newBalance = (envelope.currentAmount || 0) + distributionAmount;
+const EnvelopeItem = memo(({ envelope, distributionAmount, updateDistribution, isProcessing }) => {
+  const newBalance = (envelope.currentBalance || 0) + distributionAmount;
 
-    return (
-      <div className="bg-white border rounded-lg p-3 sm:p-4 hover:bg-gray-50 transition-colors">
-        <div className="flex flex-col sm:flex-row sm:items-center justify-between space-y-2 sm:space-y-0">
-          <div className="flex items-center flex-1">
-            <div
-              className="w-3 h-3 rounded-full mr-3 flex-shrink-0"
-              style={{ backgroundColor: envelope.color }}
-            />
-            <div className="flex-1 min-w-0">
-              <h5 className="font-medium text-gray-900 text-sm truncate">
-                {envelope.name}
-              </h5>
-              <p className="text-xs text-gray-600 truncate">
-                Current: ${(envelope.currentAmount || 0).toFixed(2)}
-                {envelope.monthlyAmount && (
-                  <span className="hidden sm:inline ml-2">
-                    • Budget: ${envelope.monthlyAmount.toFixed(2)}/month
-                  </span>
-                )}
-              </p>
-            </div>
-          </div>
-
-          <div className="flex items-center justify-between sm:justify-end space-x-3">
-            <div className="text-right">
-              <input
-                type="number"
-                step="0.01"
-                min="0"
-                value={distributionAmount || ""}
-                onChange={(e) =>
-                  updateDistribution(envelope.id, e.target.value)
-                }
-                disabled={isProcessing}
-                className="w-20 sm:w-24 px-2 py-2 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
-                placeholder="0.00"
-              />
-              {distributionAmount > 0 && (
-                <div className="text-xs text-gray-500 mt-1">
-                  New: ${newBalance.toFixed(2)}
-                </div>
+  return (
+    <div className="bg-white border rounded-lg p-3 sm:p-4 hover:bg-gray-50 transition-colors">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between space-y-2 sm:space-y-0">
+        <div className="flex items-center flex-1">
+          <div
+            className="w-3 h-3 rounded-full mr-3 flex-shrink-0"
+            style={{ backgroundColor: envelope.color }}
+          />
+          <div className="flex-1 min-w-0">
+            <h5 className="font-medium text-gray-900 text-sm truncate">{envelope.name}</h5>
+            <p className="text-xs text-gray-600 truncate">
+              Current: ${(envelope.currentBalance || 0).toFixed(2)}
+              {(envelope.monthlyBudget ?? envelope.monthlyAmount) && (
+                <span className="hidden sm:inline ml-2">
+                  • Budget: ${(envelope.monthlyBudget ?? envelope.monthlyAmount).toFixed(2)}/month
+                </span>
               )}
-            </div>
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between sm:justify-end space-x-3">
+          <div className="text-right">
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              value={distributionAmount || ""}
+              onChange={(e) => updateDistribution(envelope.id, e.target.value)}
+              disabled={isProcessing}
+              className="w-20 sm:w-24 px-2 py-2 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+              placeholder="0.00"
+            />
+            {distributionAmount > 0 && (
+              <div className="text-xs text-gray-500 mt-1">New: ${newBalance.toFixed(2)}</div>
+            )}
           </div>
         </div>
       </div>
-    );
-  },
-);
+    </div>
+  );
+});
 
 const UnassignedCashModal = () => {
-  const { isUnassignedCashModalOpen, closeUnassignedCashModal } =
-    useBudgetStore();
+  const { isUnassignedCashModalOpen, closeUnassignedCashModal } = useBudgetStore();
   const {
     // State (except modal state)
     distributions,
@@ -109,9 +100,7 @@ const UnassignedCashModal = () => {
         <div className="flex justify-between items-start mb-4 sm:mb-6">
           <div className="flex-1">
             <h3 className="text-lg font-semibold text-gray-900">
-              {unassignedCash < 0
-                ? "Address Budget Deficit"
-                : "Distribute Unassigned Cash"}
+              {unassignedCash < 0 ? "Address Budget Deficit" : "Distribute Unassigned Cash"}
             </h3>
             <p className="text-sm text-gray-600 mt-1">
               {unassignedCash < 0 ? "Deficit:" : "Available:"}{" "}
@@ -140,9 +129,7 @@ const UnassignedCashModal = () => {
         <div className="bg-gray-50 rounded-lg p-3 sm:p-4 mb-4 sm:mb-6">
           <div className="grid grid-cols-3 sm:grid-cols-3 gap-2 sm:gap-4">
             <div className="text-center">
-              <div className="text-xs sm:text-sm text-gray-600">
-                Distributing
-              </div>
+              <div className="text-xs sm:text-sm text-gray-600">Distributing</div>
               <div
                 className={`text-lg sm:text-xl font-bold ${isOverDistributed ? "text-red-600" : "text-blue-600"}`}
               >
@@ -170,9 +157,7 @@ const UnassignedCashModal = () => {
                 ) : hasDistributions ? (
                   <div className="flex items-center text-green-600">
                     <CheckCircle className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
-                    <span className="text-xs sm:text-sm font-medium">
-                      Ready
-                    </span>
+                    <span className="text-xs sm:text-sm font-medium">Ready</span>
                   </div>
                 ) : (
                   <div className="flex items-center text-gray-500">
@@ -242,16 +227,11 @@ const UnassignedCashModal = () => {
         {/* Preview Section */}
         {preview.length > 0 && (
           <div className="mt-6 pt-4 border-t border-gray-200">
-            <h4 className="font-medium text-gray-900 mb-3">
-              Distribution Preview
-            </h4>
+            <h4 className="font-medium text-gray-900 mb-3">Distribution Preview</h4>
             <div className="bg-blue-50 rounded-lg p-3 max-h-32 overflow-y-auto">
               <div className="space-y-1">
                 {preview.map((envelope) => (
-                  <div
-                    key={envelope.id}
-                    className="flex justify-between text-sm"
-                  >
+                  <div key={envelope.id} className="flex justify-between text-sm">
                     <span className="text-gray-700">{envelope.name}</span>
                     <span className="text-blue-600 font-medium">
                       +${envelope.distributionAmount.toFixed(2)}


### PR DESCRIPTION
## Summary
- use envelope query data instead of budget store in unassigned cash hook
- update UnassignedCashModal to use current balances and show budget amounts

## Testing
- `npm test -- --run` *(fails: Debt Strategy Calculations)*
- `npm run lint` *(fails: ESLint found too many warnings)*
- `npm run format:check` *(fails: Code style issues in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_689de97c20b8832c8b0f09774cf7bd28