### PR TITLE
fix: validate encryption key before syncing

### DIFF
--- a/src/components/settings/SettingsDashboard.jsx
+++ b/src/components/settings/SettingsDashboard.jsx
@@ -71,7 +71,7 @@ const SettingsDashboard = ({
         const authState = useAuth.getState();
 
         if (authState.encryptionKey && authState.currentUser && authState.budgetId) {
-          CloudSyncService.start({
+          await CloudSyncService.start({
             encryptionKey: authState.encryptionKey,
             currentUser: authState.currentUser,
             budgetId: authState.budgetId,
@@ -105,7 +105,7 @@ const SettingsDashboard = ({
         const authState = useAuth.getState();
 
         if (authState.encryptionKey && authState.currentUser && authState.budgetId) {
-          CloudSyncService.start({
+          await CloudSyncService.start({
             encryptionKey: authState.encryptionKey,
             currentUser: authState.currentUser,
             budgetId: authState.budgetId,

--- a/src/stores/budgetStore.js
+++ b/src/stores/budgetStore.js
@@ -179,7 +179,7 @@ const storeInitializer = (set, get) => ({
 
       // Import and start the background sync service
       const { default: CloudSyncService } = await import("../services/cloudSyncService");
-      CloudSyncService.start({
+      await CloudSyncService.start({
         encryptionKey: authState.encryptionKey,
         currentUser: authState.currentUser,
         budgetId: authState.budgetId,

--- a/src/utils/syncFlowValidator.js
+++ b/src/utils/syncFlowValidator.js
@@ -243,7 +243,7 @@ export const validateAllSyncFlows = async () => {
     };
 
     // Start service
-    cloudSyncService.start(testConfig);
+    await cloudSyncService.start(testConfig);
     const runningStatus = cloudSyncService.getStatus();
 
     // Stop service


### PR DESCRIPTION
## Summary
- validate and normalize provided encryption keys in CloudSyncService
- support Uint8Array keys in chunked sync initialization
- await cloud sync start in UI and utilities
- include debts and budget metadata (unassigned cash, actual bank balance) in chunked sync
- count debts during sync analysis and migration to ensure debt-only budgets sync

## Testing
- `npm test` (fails: Debt Strategy Calculations)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a499c44278832cab0eda2f9dc6232e