### PR TITLE
fix: prevent TDZ error in debt strategies helpers

### DIFF
--- a/src/utils/debtStrategies.js
+++ b/src/utils/debtStrategies.js
@@ -12,118 +12,46 @@ export const DEBT_STRATEGIES = {
   CUSTOM: "custom", // User-defined priority
 };
 
-/**
- * Calculate debt avalanche strategy (highest interest rate first)
- * @param {Array} debts - Array of debt objects
- * @param {number} extraPayment - Additional monthly payment amount
- * @returns {Object} Strategy analysis with payoff order and projections
- */
-export const calculateDebtAvalanche = (debts, extraPayment = 0) => {
-  const activeDebts = debts.filter(
-    (debt) => debt.status === "active" && debt.currentBalance > 0,
-  );
-
-  // Sort by interest rate (highest first)
-  const sortedDebts = [...activeDebts].sort(
-    (a, b) => (b.interestRate || 0) - (a.interestRate || 0),
-  );
-
-  return calculatePayoffStrategy(sortedDebts, extraPayment, "avalanche");
-};
+// Helper functions (placed before usage to avoid temporal dead zone issues)
 
 /**
- * Calculate debt snowball strategy (smallest balance first)
- * @param {Array} debts - Array of debt objects
- * @param {number} extraPayment - Additional monthly payment amount
- * @returns {Object} Strategy analysis with payoff order and projections
+ * Simulate minimum payments only (for comparison baseline)
+ * @param {Array} debts - Original debt array
+ * @returns {Object} Baseline simulation results
  */
-export const calculateDebtSnowball = (debts, extraPayment = 0) => {
-  const activeDebts = debts.filter(
-    (debt) => debt.status === "active" && debt.currentBalance > 0,
-  );
+function simulateMinimumPayments(debts) {
+  // Simple baseline calculation - minimum payments only
+  return debts.reduce(
+    (total, debt) => {
+      if (!debt.currentBalance || !debt.minimumPayment || !debt.interestRate) {
+        return total;
+      }
 
-  // Sort by balance (smallest first)
-  const sortedDebts = [...activeDebts].sort(
-    (a, b) => (a.currentBalance || 0) - (b.currentBalance || 0),
-  );
+      const monthlyRate = debt.interestRate / 100 / 12;
+      const balance = debt.currentBalance;
+      const payment = debt.minimumPayment;
 
-  return calculatePayoffStrategy(sortedDebts, extraPayment, "snowball");
-};
+      // Calculate months to payoff with minimum payments
+      let months = 0;
+      if (payment > balance * monthlyRate) {
+        months = Math.ceil(
+          -Math.log(1 - (balance * monthlyRate) / payment) /
+            Math.log(1 + monthlyRate),
+        );
+      } else {
+        months = 600; // Never pays off (minimum < interest)
+      }
 
-/**
- * Calculate custom debt strategy based on user-defined priorities
- * @param {Array} debts - Array of debt objects with priority field
- * @param {number} extraPayment - Additional monthly payment amount
- * @returns {Object} Strategy analysis with payoff order and projections
- */
-export const calculateCustomStrategy = (debts, extraPayment = 0) => {
-  const activeDebts = debts.filter(
-    (debt) => debt.status === "active" && debt.currentBalance > 0,
-  );
+      const totalInterest = payment * months - balance;
 
-  // Sort by user-defined priority (highest priority first)
-  const sortedDebts = [...activeDebts].sort(
-    (a, b) => (b.priority || 1) - (a.priority || 1),
-  );
-
-  return calculatePayoffStrategy(sortedDebts, extraPayment, "custom");
-};
-
-/**
- * Core strategy calculation function
- * @param {Array} sortedDebts - Debts sorted by strategy priority
- * @param {number} extraPayment - Additional monthly payment
- * @param {string} strategyType - Type of strategy being calculated
- * @returns {Object} Complete strategy analysis
- */
-const calculatePayoffStrategy = (sortedDebts, extraPayment, strategyType) => {
-  if (sortedDebts.length === 0) {
-    return {
-      strategy: strategyType,
-      totalMonths: 0,
-      totalInterest: 0,
-      monthlySavings: 0,
-      payoffOrder: [],
-      monthlyBreakdown: [],
-      summary: {
-        totalDebt: 0,
-        totalMinimumPayment: 0,
-        recommendedExtraPayment: extraPayment,
-        estimatedPayoffDate: null,
-      },
-    };
-  }
-
-  const totalMinimumPayment = sortedDebts.reduce(
-    (sum, debt) => sum + (debt.minimumPayment || 0),
-    0,
-  );
-
-  const totalDebt = sortedDebts.reduce(
-    (sum, debt) => sum + (debt.currentBalance || 0),
-    0,
-  );
-
-  // Calculate month-by-month payoff simulation
-  const simulation = simulatePayoffStrategy(sortedDebts, extraPayment);
-
-  return {
-    strategy: strategyType,
-    totalMonths: simulation.totalMonths,
-    totalInterest: simulation.totalInterest,
-    totalSavings: simulation.interestSaved,
-    payoffOrder: simulation.payoffOrder,
-    monthlyBreakdown: simulation.monthlyBreakdown.slice(0, 60), // Limit to 5 years for display
-    summary: {
-      totalDebt,
-      totalMinimumPayment,
-      recommendedExtraPayment: extraPayment,
-      totalPayment: totalDebt + simulation.totalInterest,
-      estimatedPayoffDate: simulation.payoffDate,
-      timeToPayoff: `${Math.floor(simulation.totalMonths / 12)} years ${simulation.totalMonths % 12} months`,
+      return {
+        totalMonths: Math.max(total.totalMonths, months),
+        totalInterest: total.totalInterest + Math.max(0, totalInterest),
+      };
     },
-  };
-};
+    { totalMonths: 0, totalInterest: 0 },
+  );
+}
 
 /**
  * Simulate month-by-month debt payoff
@@ -131,7 +59,7 @@ const calculatePayoffStrategy = (sortedDebts, extraPayment, strategyType) => {
  * @param {number} extraPayment - Extra monthly payment
  * @returns {Object} Detailed simulation results
  */
-const simulatePayoffStrategy = (debts, extraPayment) => {
+function simulatePayoffStrategy(debts, extraPayment) {
   // Create working copies of debts
   let workingDebts = debts.map((debt) => ({
     ...debt,
@@ -233,45 +161,119 @@ const simulatePayoffStrategy = (debts, extraPayment) => {
     monthlyBreakdown,
     payoffDate: new Date(Date.now() + currentMonth * 30 * 24 * 60 * 60 * 1000), // Approximate
   };
+}
+
+/**
+ * Core strategy calculation function
+ * @param {Array} sortedDebts - Debts sorted by strategy priority
+ * @param {number} extraPayment - Additional monthly payment
+ * @param {string} strategyType - Type of strategy being calculated
+ * @returns {Object} Complete strategy analysis
+ */
+function calculatePayoffStrategy(sortedDebts, extraPayment, strategyType) {
+  if (sortedDebts.length === 0) {
+    return {
+      strategy: strategyType,
+      totalMonths: 0,
+      totalInterest: 0,
+      monthlySavings: 0,
+      payoffOrder: [],
+      monthlyBreakdown: [],
+      summary: {
+        totalDebt: 0,
+        totalMinimumPayment: 0,
+        recommendedExtraPayment: extraPayment,
+        estimatedPayoffDate: null,
+      },
+    };
+  }
+
+  const totalMinimumPayment = sortedDebts.reduce(
+    (sum, debt) => sum + (debt.minimumPayment || 0),
+    0,
+  );
+
+  const totalDebt = sortedDebts.reduce(
+    (sum, debt) => sum + (debt.currentBalance || 0),
+    0,
+  );
+
+  // Calculate month-by-month payoff simulation
+  const simulation = simulatePayoffStrategy(sortedDebts, extraPayment);
+
+  return {
+    strategy: strategyType,
+    totalMonths: simulation.totalMonths,
+    totalInterest: simulation.totalInterest,
+    totalSavings: simulation.interestSaved,
+    payoffOrder: simulation.payoffOrder,
+    monthlyBreakdown: simulation.monthlyBreakdown.slice(0, 60), // Limit to 5 years for display
+    summary: {
+      totalDebt,
+      totalMinimumPayment,
+      recommendedExtraPayment: extraPayment,
+      totalPayment: totalDebt + simulation.totalInterest,
+      estimatedPayoffDate: simulation.payoffDate,
+      timeToPayoff: `${Math.floor(simulation.totalMonths / 12)} years ${simulation.totalMonths % 12} months`,
+    },
+  };
+}
+
+/**
+ * Calculate debt avalanche strategy (highest interest rate first)
+ * @param {Array} debts - Array of debt objects
+ * @param {number} extraPayment - Additional monthly payment amount
+ * @returns {Object} Strategy analysis with payoff order and projections
+ */
+export const calculateDebtAvalanche = (debts, extraPayment = 0) => {
+  const activeDebts = debts.filter(
+    (debt) => debt.status === "active" && debt.currentBalance > 0,
+  );
+
+  // Sort by interest rate (highest first)
+  const sortedDebts = [...activeDebts].sort(
+    (a, b) => (b.interestRate || 0) - (a.interestRate || 0),
+  );
+
+  return calculatePayoffStrategy(sortedDebts, extraPayment, "avalanche");
 };
 
 /**
- * Simulate minimum payments only (for comparison baseline)
- * @param {Array} debts - Original debt array
- * @returns {Object} Baseline simulation results
+ * Calculate debt snowball strategy (smallest balance first)
+ * @param {Array} debts - Array of debt objects
+ * @param {number} extraPayment - Additional monthly payment amount
+ * @returns {Object} Strategy analysis with payoff order and projections
  */
-const simulateMinimumPayments = (debts) => {
-  // Simple baseline calculation - minimum payments only
-  return debts.reduce(
-    (total, debt) => {
-      if (!debt.currentBalance || !debt.minimumPayment || !debt.interestRate) {
-        return total;
-      }
-
-      const monthlyRate = debt.interestRate / 100 / 12;
-      const balance = debt.currentBalance;
-      const payment = debt.minimumPayment;
-
-      // Calculate months to payoff with minimum payments
-      let months = 0;
-      if (payment > balance * monthlyRate) {
-        months = Math.ceil(
-          -Math.log(1 - (balance * monthlyRate) / payment) /
-            Math.log(1 + monthlyRate),
-        );
-      } else {
-        months = 600; // Never pays off (minimum < interest)
-      }
-
-      const totalInterest = payment * months - balance;
-
-      return {
-        totalMonths: Math.max(total.totalMonths, months),
-        totalInterest: total.totalInterest + Math.max(0, totalInterest),
-      };
-    },
-    { totalMonths: 0, totalInterest: 0 },
+export const calculateDebtSnowball = (debts, extraPayment = 0) => {
+  const activeDebts = debts.filter(
+    (debt) => debt.status === "active" && debt.currentBalance > 0,
   );
+
+  // Sort by balance (smallest first)
+  const sortedDebts = [...activeDebts].sort(
+    (a, b) => (a.currentBalance || 0) - (b.currentBalance || 0),
+  );
+
+  return calculatePayoffStrategy(sortedDebts, extraPayment, "snowball");
+};
+
+/**
+ * Calculate custom debt strategy based on user-defined priorities
+ * @param {Array} debts - Array of debt objects with priority field
+ * @param {number} extraPayment - Additional monthly payment amount
+ * @returns {Object} Strategy analysis with payoff order and projections
+ */
+export const calculateCustomStrategy = (debts, extraPayment = 0) => {
+  const activeDebts = debts.filter(
+    (debt) => debt.status === "active" && debt.currentBalance > 0,
+  );
+
+  // Sort by user-defined priority (highest priority first)
+  const sortedDebts = [...activeDebts].sort(
+    (a, b) => (b.priority || 1) - (a.priority || 1),
+  );
+
+  return calculatePayoffStrategy(sortedDebts, extraPayment, "custom");
 };
 
 /**


### PR DESCRIPTION
## Summary
- hoist debt strategy helper functions to avoid temporal dead zone errors

## Testing
- `npm test` (fails: expected undefined to be defined)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a850ae5c68832c8fb7d5cab0ffee0d