### PR TITLE
feat: add payment plan details to debt strategies

### DIFF
--- a/src/utils/debtStrategies.js
+++ b/src/utils/debtStrategies.js
@@ -200,9 +200,15 @@ function calculatePayoffStrategy(sortedDebts, extraPayment, strategyType) {
 
   // Calculate month-by-month payoff simulation
   const simulation = simulatePayoffStrategy(sortedDebts, extraPayment);
+  // Build simplified payment plan used by older utilities/tests
+  const paymentPlan = sortedDebts.map((debt, index) => ({
+    ...debt,
+    priorityOrder: index + 1,
+  }));
 
   return {
     strategy: strategyType,
+    paymentPlan,
     totalMonths: simulation.totalMonths,
     totalInterest: simulation.totalInterest,
     totalSavings: simulation.interestSaved,
@@ -212,6 +218,7 @@ function calculatePayoffStrategy(sortedDebts, extraPayment, strategyType) {
       totalDebt,
       totalMinimumPayment,
       recommendedExtraPayment: extraPayment,
+      totalInterestPaid: simulation.totalInterest,
       totalPayment: totalDebt + simulation.totalInterest,
       estimatedPayoffDate: simulation.payoffDate,
       timeToPayoff: `${Math.floor(simulation.totalMonths / 12)} years ${simulation.totalMonths % 12} months`,


### PR DESCRIPTION
## Summary
- enrich debt strategy output with `paymentPlan` entries including priority order
- expose `totalInterestPaid` in summary for payoff calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a99ce09748832c8533539f9e6c4e61