### PR TITLE
fix(ci): prevent duplicate code quality check comments on PRs

### DIFF
--- a/.github/workflows/code-quality-tracker.yml
+++ b/.github/workflows/code-quality-tracker.yml
@@ -20,6 +20,11 @@ on:
   # Manual trigger option
   workflow_dispatch:
 
+# Prevent duplicate runs for the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
   pull-requests: write
@@ -164,7 +169,7 @@ jobs:
               console.log('✅ TypeScript check passed - no comment posted');
             }
 
-      - name: Create summary comment on PR
+      - name: Create or update summary comment on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
@@ -184,15 +189,41 @@ jobs:
             const commentBody = '## ' + statusEmoji + ' Code Quality Check\n\n' +
               '**ESLint**: ' + eslintTotal + ' issues\n' +
               '**TypeScript**: ' + tsTotal + ' compilation errors\n\n' +
-              mergeStatus;
+              mergeStatus + '\n\n' +
+              '_Last updated: ' + new Date().toLocaleString('en-US', { timeZone: 'UTC' }) + ' UTC_';
 
             try {
-              await github.rest.issues.createComment({
+              // Find existing comment from this bot
+              const comments = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: commentBody
               });
+
+              const botComment = comments.data.find(comment => 
+                comment.user.type === 'Bot' && 
+                comment.body.includes('Code Quality Check')
+              );
+
+              if (botComment) {
+                // Update existing comment
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: commentBody
+                });
+                console.log('✅ Updated existing code quality comment');
+              } else {
+                // Create new comment
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: commentBody
+                });
+                console.log('✅ Created new code quality comment');
+              }
             } catch (error) {
-              console.log('Could not create PR comment:', error.message);
+              console.log('❌ Could not create/update PR comment:', error.message);
             }


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes the issue where the code quality tracker workflow was posting 4+ duplicate comments on PRs.

### 🔧 Changes

1. **Added concurrency group** to prevent multiple simultaneous workflow runs
   - Groups runs by workflow + PR number
   - Cancels in-progress runs when new commits are pushed

2. **Update existing comments** instead of creating new ones
   - Finds existing bot comment with "Code Quality Check" text
   - Updates it with latest metrics
   - Adds timestamp for tracking

### ✅ Testing

- Verified concurrency configuration syntax
- Tested comment update logic (finds and updates existing bot comments)

### 📋 Related

- Resolves duplicate comment issue reported by user
- Cherry-picked from develop (commit: 180850ec)

Co-authored-by: Claude <noreply@anthropic.com>